### PR TITLE
prevent reg journey updates

### DIFF
--- a/src/EPR.SubmissionMicroservice.Application.UnitTests/Features/Commands/SubmissionSubmit/SubmissionSubmitCommandHandlerTests.cs
+++ b/src/EPR.SubmissionMicroservice.Application.UnitTests/Features/Commands/SubmissionSubmit/SubmissionSubmitCommandHandlerTests.cs
@@ -85,23 +85,6 @@ public class SubmissionSubmitCommandHandlerTests
     }
 
     [TestMethod]
-    public async Task Handle_UpdatesSubmissionWithProvidedProducerSizeValue()
-    {
-        var command = new SubmissionSubmitCommand { SubmissionId = _submissionId, UserId = _userId, FileId = _fileId, RegistrationJourney = "TO_BE_UPDATED" };
-        var submission = new Submission { Id = _submissionId, SubmissionType = SubmissionType.Producer, IsSubmitted = false, RegistrationJourney = "TO_NOT_BE_USED" };
-
-        _submissionQueryRepositoryMock.Setup(x => x.GetByIdAsync(_submissionId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(submission);
-        _pomSubmissionEventHelperMock.Setup(x => x.VerifyFileIdIsForValidFileAsync(_submissionId, _fileId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-
-        var result = await _testSubmissionSubmitCommandHandler.Handle(command, CancellationToken.None);
-
-        result.IsError.Should().BeFalse();
-        _submissionCommandRepositoryMock.Verify(x => x.Update(It.Is<Submission>(s => s.RegistrationJourney == "TO_BE_UPDATED")), Times.Once);
-    }
-
-    [TestMethod]
     public async Task Handle_DoesNotCallsUpdateSubmissionAndCreatesASubmittedEvent_WhenSubmissionHasBeenSubmittedPreviously()
     {
         // Arrange

--- a/src/EPR.SubmissionMicroservice.Application/Features/Commands/SubmissionSubmit/SubmissionSubmitCommand.cs
+++ b/src/EPR.SubmissionMicroservice.Application/Features/Commands/SubmissionSubmit/SubmissionSubmitCommand.cs
@@ -16,6 +16,4 @@ public class SubmissionSubmitCommand : IRequest<ErrorOr<Unit>>
     public string? AppReferenceNumber { get; set; }
 
     public bool? IsResubmission { get; set; }
-
-    public string? RegistrationJourney { get; set; }
 }

--- a/src/EPR.SubmissionMicroservice.Application/Features/Commands/SubmissionSubmit/SubmissionSubmitCommandHandler.cs
+++ b/src/EPR.SubmissionMicroservice.Application/Features/Commands/SubmissionSubmit/SubmissionSubmitCommandHandler.cs
@@ -49,7 +49,6 @@ public class SubmissionSubmitCommandHandler(
             submission.IsSubmitted = true;
             submission.IsResubmission = command.IsResubmission;
             submission.AppReferenceNumber = command.AppReferenceNumber;
-            submission.RegistrationJourney = command.RegistrationJourney;
             submissionCommandRepository.Update(submission);
 
             var submittedEvent = new SubmittedEvent


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SMAL-171

Don't try updating the submission registration journey always use the current value

* Updated the `SubmissionSubmitCommandHandler` so that it doesn't overwrite the `RegistrationJourney`
* Removed unit test

<img width="1226" height="847" alt="image" src="https://github.com/user-attachments/assets/4c5aa3b5-89d3-46d1-b5e1-52584c2a43ac" />
