### PR TITLE
Feature/sub 149 hydrate submission

### DIFF
--- a/src/EPR.SubmissionMicroservice.Application.UnitTests/EPR.SubmissionMicroservice.Application.UnitTests.csproj
+++ b/src/EPR.SubmissionMicroservice.Application.UnitTests/EPR.SubmissionMicroservice.Application.UnitTests.csproj
@@ -10,6 +10,7 @@
         <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="AutoFixture" Version="4.18.1" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="ILogger.Moq" Version="1.1.10" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />

--- a/src/EPR.SubmissionMicroservice.Application.UnitTests/Features/Queries/Common/Services/SubmissionHydrationServiceTests.cs
+++ b/src/EPR.SubmissionMicroservice.Application.UnitTests/Features/Queries/Common/Services/SubmissionHydrationServiceTests.cs
@@ -1,0 +1,192 @@
+namespace EPR.SubmissionMicroservice.Application.UnitTests.Features.Queries.Common.Services;
+
+using Application.Features.Queries.Common;
+using Application.Features.Queries.Common.Services;
+using Data.Enums;
+
+[TestClass]
+public class SubmissionHydrationServiceTests
+{
+    private SubmissionHydrationService _sut;
+
+    [TestInitialize]
+    public void SetUp()
+    {
+        _sut = new SubmissionHydrationService();
+    }
+
+    [TestMethod]
+    public void Hydrate_WhenSubmissionTypeIsNotRegistration_ShouldNotModifySubmission()
+    {
+        // Arrange
+        var submission = CreateTestSubmission(submissionType: SubmissionType.Producer, submissionPeriod: "Apr2026");
+        var originalYear = submission.RegistrationYear;
+        var originalJourney = submission.RegistrationJourney;
+
+        // Act
+        _sut.Hydrate(submission);
+
+        // Assert
+        submission.RegistrationYear.Should().Be(originalYear);
+        submission.RegistrationJourney.Should().Be(originalJourney);
+    }
+
+    [TestMethod]
+    public void Hydrate_WhenSubmissionTypeIsRegistrationWithValidYear_ShouldSetRegistrationYear()
+    {
+        // Arrange
+        var submission = CreateTestSubmission(submissionType: SubmissionType.Registration, submissionPeriod: "Apr2026");
+
+        // Act
+        _sut.Hydrate(submission);
+
+        // Assert
+        submission.RegistrationYear.Should().Be(2026);
+    }
+
+    [TestMethod]
+    public void Hydrate_WhenSubmissionTypeIsRegistrationWith2025Year_ShouldSetRegistrationYearCorrectly()
+    {
+        // Arrange
+        var submission = CreateTestSubmission(submissionType: SubmissionType.Registration, submissionPeriod: "Apr2025");
+
+        // Act
+        _sut.Hydrate(submission);
+
+        // Assert
+        submission.RegistrationYear.Should().Be(2025);
+    }
+
+    [TestMethod]
+    public void Hydrate_WhenSubmissionTypeIsRegistrationWithInvalidYear_ShouldNotSetRegistrationYear()
+    {
+        // Arrange
+        var submission = CreateTestSubmission(submissionType: SubmissionType.Registration, submissionPeriod: "PXXX");
+
+        // Act
+        _sut.Hydrate(submission);
+
+        // Assert
+        submission.RegistrationYear.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Hydrate_WhenSubmissionPeriodLessThan4Chars_ShouldNotSetRegistrationYear()
+    {
+        // Arrange
+        var submission = CreateTestSubmission(submissionType: SubmissionType.Registration, submissionPeriod: "P");
+
+        // Act
+        _sut.Hydrate(submission);
+
+        // Assert
+        submission.RegistrationYear.Should().BeNull();
+        submission.RegistrationJourney.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Hydrate_WhenSubmissionTypeIsRegistrationWith2026AndComplianceSchemeAndNullJourney_ShouldSetRegistrationJourneyToCsoLargeProducer()
+    {
+        // Arrange
+        var complianceSchemeId = Guid.NewGuid();
+        var submission = CreateTestSubmission(
+            submissionType: SubmissionType.Registration,
+            submissionPeriod: "Apr2026",
+            complianceSchemeId: complianceSchemeId,
+            registrationJourney: null);
+
+        // Act
+        _sut.Hydrate(submission);
+
+        // Assert
+        submission.RegistrationYear.Should().Be(2026);
+        submission.RegistrationJourney.Should().Be(RegistrationJourney.CsoLargeProducer.ToString());
+    }
+
+    [TestMethod]
+    public void Hydrate_WhenSubmissionTypeIsRegistrationWith2026AndNoComplianceScheme_ShouldNotSetRegistrationJourney()
+    {
+        // Arrange
+        var submission = CreateTestSubmission(
+            submissionType: SubmissionType.Registration,
+            submissionPeriod: "Apr2026",
+            complianceSchemeId: null,
+            registrationJourney: null);
+
+        // Act
+        _sut.Hydrate(submission);
+
+        // Assert
+        submission.RegistrationYear.Should().Be(2026);
+        submission.RegistrationJourney.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Hydrate_WhenSubmissionTypeIsRegistrationWith2026AndExistingJourney_ShouldNotOverwriteRegistrationJourney()
+    {
+        // Arrange
+        var complianceSchemeId = Guid.NewGuid();
+        var existingJourney = RegistrationJourney.DirectLargeProducer.ToString();
+        var submission = CreateTestSubmission(
+            submissionType: SubmissionType.Registration,
+            submissionPeriod: "Apr2026",
+            complianceSchemeId: complianceSchemeId,
+            registrationJourney: existingJourney);
+
+        // Act
+        _sut.Hydrate(submission);
+
+        // Assert
+        submission.RegistrationYear.Should().Be(2026);
+        submission.RegistrationJourney.Should().Be(existingJourney);
+    }
+
+    [TestMethod]
+    public void Hydrate_WhenSubmissionTypeIsRegistrationWith2025AndComplianceScheme_ShouldNotSetRegistrationJourney()
+    {
+        // Arrange
+        var complianceSchemeId = Guid.NewGuid();
+        var submission = CreateTestSubmission(
+            submissionType: SubmissionType.Registration,
+            submissionPeriod: "Apr2025",
+            complianceSchemeId: complianceSchemeId,
+            registrationJourney: null);
+
+        // Act
+        _sut.Hydrate(submission);
+
+        // Assert
+        submission.RegistrationYear.Should().Be(2025);
+        submission.RegistrationJourney.Should().BeNull();
+    }
+
+    private TestSubmissionGetResponse CreateTestSubmission(
+        SubmissionType submissionType,
+        string submissionPeriod,
+        Guid? complianceSchemeId = null,
+        string? registrationJourney = null)
+    {
+        return new TestSubmissionGetResponse
+        {
+            Id = Guid.NewGuid(),
+            DataSourceType = DataSourceType.File,
+            SubmissionType = submissionType,
+            SubmissionPeriod = submissionPeriod,
+            OrganisationId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Created = DateTime.UtcNow,
+            ValidationPass = true,
+            HasWarnings = false,
+            Errors = new List<string>(),
+            IsSubmitted = true,
+            ComplianceSchemeId = complianceSchemeId,
+            RegistrationJourney = registrationJourney,
+            RegistrationYear = null
+        };
+    }
+
+    private class TestSubmissionGetResponse : AbstractSubmissionGetResponse
+    {
+        public override bool HasValidFile => true;
+    }
+}

--- a/src/EPR.SubmissionMicroservice.Application.UnitTests/Features/Queries/SubmissionGet/HydrateSubmissionBehaviourTests.cs
+++ b/src/EPR.SubmissionMicroservice.Application.UnitTests/Features/Queries/SubmissionGet/HydrateSubmissionBehaviourTests.cs
@@ -1,0 +1,270 @@
+using EPR.SubmissionMicroservice.Application.Features.Queries.Common;
+using EPR.SubmissionMicroservice.Application.Features.Queries.SubmissionGet;
+using EPR.SubmissionMicroservice.Data.Enums;
+using MediatR;
+
+namespace EPR.SubmissionMicroservice.Application.UnitTests.Features.Queries.SubmissionGet;
+
+[TestClass]
+public class HydrateSubmissionBehaviourTests
+{
+    [TestMethod]
+    public async Task Handle_WhenResponseIsError_ShouldReturnError()
+    {
+        // Arrange
+        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
+        var cancellationToken = CancellationToken.None;
+        var testError = Error.Custom(1, "TestError", "Test error description");
+        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
+        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(testError);
+
+        var behaviour = new HydrateSubmissionBehaviour();
+
+        // Act
+        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Should().Be(testError);
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenSubmissionTypeIsNotRegistration_ShouldReturnSubmissionUnchanged()
+    {
+        // Arrange
+        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
+        var cancellationToken = CancellationToken.None;
+        var submission = CreateTestSubmission(submissionType: SubmissionType.Producer, submissionPeriod: "2025");
+        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
+        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
+
+        var behaviour = new HydrateSubmissionBehaviour();
+
+        // Act
+        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be(submission);
+        result.Value.RegistrationYear.Should().BeNull();
+        result.Value.RegistrationJourney.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenSubmissionTypeIsRegistrationWithValidYear_ShouldSetRegistrationYear()
+    {
+        // Arrange
+        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
+        var cancellationToken = CancellationToken.None;
+        var submission = CreateTestSubmission(submissionType: SubmissionType.Registration, submissionPeriod: "Apr2026");
+        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
+        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
+
+        var behaviour = new HydrateSubmissionBehaviour();
+
+        // Act
+        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.RegistrationYear.Should().Be(2026);
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenSubmissionTypeIsRegistrationWith2025Year_ShouldSetRegistrationYearCorrectly()
+    {
+        // Arrange
+        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
+        var cancellationToken = CancellationToken.None;
+        var submission = CreateTestSubmission(submissionType: SubmissionType.Registration, submissionPeriod: "Apr2025");
+        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
+        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
+
+        var behaviour = new HydrateSubmissionBehaviour();
+
+        // Act
+        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.RegistrationYear.Should().Be(2025);
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenSubmissionTypeIsRegistrationWithInvalidYear_ShouldNotSetRegistrationYear()
+    {
+        // Arrange
+        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
+        var cancellationToken = CancellationToken.None;
+        var submission = CreateTestSubmission(submissionType: SubmissionType.Registration, submissionPeriod: "PXXX");
+        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
+        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
+
+        var behaviour = new HydrateSubmissionBehaviour();
+
+        // Act
+        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.RegistrationYear.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenSubmissionTypeIsRegistrationWithShortPeriod_ShouldNotSetRegistrationYear()
+    {
+        // Arrange
+        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
+        var cancellationToken = CancellationToken.None;
+        var submission = CreateTestSubmission(submissionType: SubmissionType.Registration, submissionPeriod: "P");
+        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
+        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
+
+        var behaviour = new HydrateSubmissionBehaviour();
+
+        // Act
+        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.RegistrationYear.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenSubmissionTypeIsRegistrationWith2026AndComplianceSchemeAndNullJourney_ShouldSetRegistrationJourneyToCsoLargeProducer()
+    {
+        // Arrange
+        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
+        var cancellationToken = CancellationToken.None;
+        var complianceSchemeId = Guid.NewGuid();
+        var submission = CreateTestSubmission(
+            submissionType: SubmissionType.Registration,
+            submissionPeriod: "Apr2026",
+            complianceSchemeId: complianceSchemeId,
+            registrationJourney: null);
+
+        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
+        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
+
+        var behaviour = new HydrateSubmissionBehaviour();
+
+        // Act
+        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.RegistrationYear.Should().Be(2026);
+        result.Value.RegistrationJourney.Should().Be(RegistrationJourney.CsoLargeProducer.ToString());
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenSubmissionTypeIsRegistrationWith2026AndNoComplianceScheme_ShouldNotSetRegistrationJourney()
+    {
+        // Arrange
+        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
+        var cancellationToken = CancellationToken.None;
+        var submission = CreateTestSubmission(
+            submissionType: SubmissionType.Registration,
+            submissionPeriod: "Apr2026",
+            complianceSchemeId: null,
+            registrationJourney: null);
+
+        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
+        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
+
+        var behaviour = new HydrateSubmissionBehaviour();
+
+        // Act
+        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.RegistrationYear.Should().Be(2026);
+        result.Value.RegistrationJourney.Should().BeNull();
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenSubmissionTypeIsRegistrationWith2026AndExistingJourney_ShouldNotOverwriteRegistrationJourney()
+    {
+        // Arrange
+        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
+        var cancellationToken = CancellationToken.None;
+        var complianceSchemeId = Guid.NewGuid();
+        var existingJourney = RegistrationJourney.DirectLargeProducer.ToString();
+        var submission = CreateTestSubmission(
+            submissionType: SubmissionType.Registration,
+            submissionPeriod: "Apr2026",
+            complianceSchemeId: complianceSchemeId,
+            registrationJourney: existingJourney);
+
+        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
+        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
+
+        var behaviour = new HydrateSubmissionBehaviour();
+
+        // Act
+        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.RegistrationYear.Should().Be(2026);
+        result.Value.RegistrationJourney.Should().Be(existingJourney);
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenSubmissionTypeIsRegistrationWith2025AndComplianceScheme_ShouldNotSetRegistrationJourney()
+    {
+        // Arrange
+        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
+        var cancellationToken = CancellationToken.None;
+        var complianceSchemeId = Guid.NewGuid();
+        var submission = CreateTestSubmission(
+            submissionType: SubmissionType.Registration,
+            submissionPeriod: "Apr2025",
+            complianceSchemeId: complianceSchemeId,
+            registrationJourney: null);
+
+        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
+        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
+
+        var behaviour = new HydrateSubmissionBehaviour();
+
+        // Act
+        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.RegistrationYear.Should().Be(2025);
+        result.Value.RegistrationJourney.Should().BeNull();
+    }
+
+    private TestSubmissionGetResponse CreateTestSubmission(
+        SubmissionType submissionType,
+        string submissionPeriod,
+        Guid? complianceSchemeId = null,
+        string? registrationJourney = null)
+    {
+        return new TestSubmissionGetResponse
+        {
+            Id = Guid.NewGuid(),
+            DataSourceType = DataSourceType.File,
+            SubmissionType = submissionType,
+            SubmissionPeriod = submissionPeriod,
+            OrganisationId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Created = DateTime.UtcNow,
+            ValidationPass = true,
+            HasWarnings = false,
+            Errors = new List<string>(),
+            IsSubmitted = true,
+            ComplianceSchemeId = complianceSchemeId,
+            RegistrationJourney = registrationJourney,
+            RegistrationYear = null
+        };
+    }
+
+    private class TestSubmissionGetResponse : AbstractSubmissionGetResponse
+    {
+        public override bool HasValidFile => true;
+    }
+}

--- a/src/EPR.SubmissionMicroservice.Application.UnitTests/Features/Queries/SubmissionGet/HydrateSubmissionBehaviourTests.cs
+++ b/src/EPR.SubmissionMicroservice.Application.UnitTests/Features/Queries/SubmissionGet/HydrateSubmissionBehaviourTests.cs
@@ -1,4 +1,5 @@
 using EPR.SubmissionMicroservice.Application.Features.Queries.Common;
+using EPR.SubmissionMicroservice.Application.Features.Queries.Common.Interfaces;
 using EPR.SubmissionMicroservice.Application.Features.Queries.SubmissionGet;
 using EPR.SubmissionMicroservice.Data.Enums;
 using MediatR;
@@ -8,8 +9,16 @@ namespace EPR.SubmissionMicroservice.Application.UnitTests.Features.Queries.Subm
 [TestClass]
 public class HydrateSubmissionBehaviourTests
 {
+    private Mock<ISubmissionHydrationService> _submissionHydrationServiceMock;
+
+    [TestInitialize]
+    public void SetUp()
+    {
+        _submissionHydrationServiceMock = new Mock<ISubmissionHydrationService>();
+    }
+
     [TestMethod]
-    public async Task Handle_WhenResponseIsError_ShouldReturnError()
+    public async Task Handle_WhenResponseIsError_ShouldReturnErrorWithoutCallingHydrationService()
     {
         // Arrange
         var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
@@ -18,7 +27,7 @@ public class HydrateSubmissionBehaviourTests
         var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
         requestHandlerDelegate.Setup(x => x()).ReturnsAsync(testError);
 
-        var behaviour = new HydrateSubmissionBehaviour();
+        var behaviour = new HydrateSubmissionBehaviour(_submissionHydrationServiceMock.Object);
 
         // Act
         var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
@@ -26,10 +35,11 @@ public class HydrateSubmissionBehaviourTests
         // Assert
         result.IsError.Should().BeTrue();
         result.FirstError.Should().Be(testError);
+        _submissionHydrationServiceMock.Verify(x => x.Hydrate(It.IsAny<AbstractSubmissionGetResponse>()), Times.Never);
     }
 
     [TestMethod]
-    public async Task Handle_WhenSubmissionTypeIsNotRegistration_ShouldReturnSubmissionUnchanged()
+    public async Task Handle_WhenResponseIsSuccess_ShouldCallHydrationServiceAndReturnSubmission()
     {
         // Arrange
         var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
@@ -38,7 +48,7 @@ public class HydrateSubmissionBehaviourTests
         var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
         requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
 
-        var behaviour = new HydrateSubmissionBehaviour();
+        var behaviour = new HydrateSubmissionBehaviour(_submissionHydrationServiceMock.Object);
 
         // Act
         var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
@@ -46,12 +56,11 @@ public class HydrateSubmissionBehaviourTests
         // Assert
         result.IsError.Should().BeFalse();
         result.Value.Should().Be(submission);
-        result.Value.RegistrationYear.Should().BeNull();
-        result.Value.RegistrationJourney.Should().BeNull();
+        _submissionHydrationServiceMock.Verify(x => x.Hydrate(submission), Times.Once);
     }
 
     [TestMethod]
-    public async Task Handle_WhenSubmissionTypeIsRegistrationWithValidYear_ShouldSetRegistrationYear()
+    public async Task Handle_WhenResponseIsSuccessWithRegistration_ShouldCallHydrationService()
     {
         // Arrange
         var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
@@ -60,182 +69,15 @@ public class HydrateSubmissionBehaviourTests
         var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
         requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
 
-        var behaviour = new HydrateSubmissionBehaviour();
+        var behaviour = new HydrateSubmissionBehaviour(_submissionHydrationServiceMock.Object);
 
         // Act
         var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
 
         // Assert
         result.IsError.Should().BeFalse();
-        result.Value.RegistrationYear.Should().Be(2026);
-    }
-
-    [TestMethod]
-    public async Task Handle_WhenSubmissionTypeIsRegistrationWith2025Year_ShouldSetRegistrationYearCorrectly()
-    {
-        // Arrange
-        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
-        var cancellationToken = CancellationToken.None;
-        var submission = CreateTestSubmission(submissionType: SubmissionType.Registration, submissionPeriod: "Apr2025");
-        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
-        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
-
-        var behaviour = new HydrateSubmissionBehaviour();
-
-        // Act
-        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
-
-        // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.RegistrationYear.Should().Be(2025);
-    }
-
-    [TestMethod]
-    public async Task Handle_WhenSubmissionTypeIsRegistrationWithInvalidYear_ShouldNotSetRegistrationYear()
-    {
-        // Arrange
-        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
-        var cancellationToken = CancellationToken.None;
-        var submission = CreateTestSubmission(submissionType: SubmissionType.Registration, submissionPeriod: "PXXX");
-        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
-        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
-
-        var behaviour = new HydrateSubmissionBehaviour();
-
-        // Act
-        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
-
-        // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.RegistrationYear.Should().BeNull();
-    }
-
-    [TestMethod]
-    public async Task Handle_WhenSubmissionTypeIsRegistrationWithShortPeriod_ShouldNotSetRegistrationYear()
-    {
-        // Arrange
-        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
-        var cancellationToken = CancellationToken.None;
-        var submission = CreateTestSubmission(submissionType: SubmissionType.Registration, submissionPeriod: "P");
-        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
-        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
-
-        var behaviour = new HydrateSubmissionBehaviour();
-
-        // Act
-        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
-
-        // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.RegistrationYear.Should().BeNull();
-    }
-
-    [TestMethod]
-    public async Task Handle_WhenSubmissionTypeIsRegistrationWith2026AndComplianceSchemeAndNullJourney_ShouldSetRegistrationJourneyToCsoLargeProducer()
-    {
-        // Arrange
-        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
-        var cancellationToken = CancellationToken.None;
-        var complianceSchemeId = Guid.NewGuid();
-        var submission = CreateTestSubmission(
-            submissionType: SubmissionType.Registration,
-            submissionPeriod: "Apr2026",
-            complianceSchemeId: complianceSchemeId,
-            registrationJourney: null);
-
-        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
-        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
-
-        var behaviour = new HydrateSubmissionBehaviour();
-
-        // Act
-        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
-
-        // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.RegistrationYear.Should().Be(2026);
-        result.Value.RegistrationJourney.Should().Be(RegistrationJourney.CsoLargeProducer.ToString());
-    }
-
-    [TestMethod]
-    public async Task Handle_WhenSubmissionTypeIsRegistrationWith2026AndNoComplianceScheme_ShouldNotSetRegistrationJourney()
-    {
-        // Arrange
-        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
-        var cancellationToken = CancellationToken.None;
-        var submission = CreateTestSubmission(
-            submissionType: SubmissionType.Registration,
-            submissionPeriod: "Apr2026",
-            complianceSchemeId: null,
-            registrationJourney: null);
-
-        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
-        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
-
-        var behaviour = new HydrateSubmissionBehaviour();
-
-        // Act
-        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
-
-        // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.RegistrationYear.Should().Be(2026);
-        result.Value.RegistrationJourney.Should().BeNull();
-    }
-
-    [TestMethod]
-    public async Task Handle_WhenSubmissionTypeIsRegistrationWith2026AndExistingJourney_ShouldNotOverwriteRegistrationJourney()
-    {
-        // Arrange
-        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
-        var cancellationToken = CancellationToken.None;
-        var complianceSchemeId = Guid.NewGuid();
-        var existingJourney = RegistrationJourney.DirectLargeProducer.ToString();
-        var submission = CreateTestSubmission(
-            submissionType: SubmissionType.Registration,
-            submissionPeriod: "Apr2026",
-            complianceSchemeId: complianceSchemeId,
-            registrationJourney: existingJourney);
-
-        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
-        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
-
-        var behaviour = new HydrateSubmissionBehaviour();
-
-        // Act
-        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
-
-        // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.RegistrationYear.Should().Be(2026);
-        result.Value.RegistrationJourney.Should().Be(existingJourney);
-    }
-
-    [TestMethod]
-    public async Task Handle_WhenSubmissionTypeIsRegistrationWith2025AndComplianceScheme_ShouldNotSetRegistrationJourney()
-    {
-        // Arrange
-        var request = new SubmissionGetQuery(Guid.NewGuid(), Guid.NewGuid());
-        var cancellationToken = CancellationToken.None;
-        var complianceSchemeId = Guid.NewGuid();
-        var submission = CreateTestSubmission(
-            submissionType: SubmissionType.Registration,
-            submissionPeriod: "Apr2025",
-            complianceSchemeId: complianceSchemeId,
-            registrationJourney: null);
-
-        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>>>();
-        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submission);
-
-        var behaviour = new HydrateSubmissionBehaviour();
-
-        // Act
-        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
-
-        // Assert
-        result.IsError.Should().BeFalse();
-        result.Value.RegistrationYear.Should().Be(2025);
-        result.Value.RegistrationJourney.Should().BeNull();
+        result.Value.Should().Be(submission);
+        _submissionHydrationServiceMock.Verify(x => x.Hydrate(submission), Times.Once);
     }
 
     private TestSubmissionGetResponse CreateTestSubmission(

--- a/src/EPR.SubmissionMicroservice.Application.UnitTests/Features/Queries/SubmissionsGet/HydrateSubmissionsBehaviourTests.cs
+++ b/src/EPR.SubmissionMicroservice.Application.UnitTests/Features/Queries/SubmissionsGet/HydrateSubmissionsBehaviourTests.cs
@@ -1,0 +1,141 @@
+namespace EPR.SubmissionMicroservice.Application.UnitTests.Features.Queries.SubmissionsGet;
+
+using Application.Features.Queries.Common;
+using Application.Features.Queries.Common.Interfaces;
+using Application.Features.Queries.SubmissionsGet;
+using Data.Enums;
+using MediatR;
+using AutoFixture;
+
+[TestClass]
+public class HydrateSubmissionsBehaviourTests
+{
+    private Mock<ISubmissionHydrationService> _submissionHydrationServiceMock;
+    private readonly IFixture _fixture = new Fixture();
+
+    [TestInitialize]
+    public void SetUp()
+    {
+        _submissionHydrationServiceMock = new Mock<ISubmissionHydrationService>();
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenResponseIsError_ShouldReturnErrorWithoutCallingHydrationService()
+    {
+        // Arrange
+        var request = _fixture.Create<SubmissionsGetQuery>();
+        var cancellationToken = CancellationToken.None;
+        var testError = Error.Custom(1, "TestError", "Test error description");
+        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<List<AbstractSubmissionGetResponse>>>>();
+        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(testError);
+
+        var behaviour = new HydrateSubmissionsBehaviour(_submissionHydrationServiceMock.Object);
+
+        // Act
+        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Should().Be(testError);
+        _submissionHydrationServiceMock.Verify(x => x.Hydrate(It.IsAny<AbstractSubmissionGetResponse>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenResponseIsEmpty_ShouldReturnEmptyListWithoutCallingHydrationService()
+    {
+        // Arrange
+        var request = _fixture.Create<SubmissionsGetQuery>();
+        var cancellationToken = CancellationToken.None;
+        var emptyList = new List<AbstractSubmissionGetResponse>();
+        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<List<AbstractSubmissionGetResponse>>>>();
+        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(emptyList);
+
+        var behaviour = new HydrateSubmissionsBehaviour(_submissionHydrationServiceMock.Object);
+
+        // Act
+        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().BeEmpty();
+        _submissionHydrationServiceMock.Verify(x => x.Hydrate(It.IsAny<AbstractSubmissionGetResponse>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenResponseHasSingleSubmission_ShouldHydrateThatSubmission()
+    {
+        // Arrange
+        var request = _fixture.Create<SubmissionsGetQuery>();
+        var cancellationToken = CancellationToken.None;
+        var submission = CreateTestSubmission(submissionType: SubmissionType.Registration, submissionPeriod: "Apr2026");
+        var submissions = new List<AbstractSubmissionGetResponse> { submission };
+        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<List<AbstractSubmissionGetResponse>>>>();
+        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submissions);
+
+        var behaviour = new HydrateSubmissionsBehaviour(_submissionHydrationServiceMock.Object);
+
+        // Act
+        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().HaveCount(1);
+        _submissionHydrationServiceMock.Verify(x => x.Hydrate(submission), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenResponseHasMultipleSubmissions_ShouldHydrateEachSubmission()
+    {
+        // Arrange
+        var request = _fixture.Create<SubmissionsGetQuery>();
+        var cancellationToken = CancellationToken.None;
+        var submission1 = CreateTestSubmission(submissionType: SubmissionType.Registration, submissionPeriod: "Apr2026");
+        var submission2 = CreateTestSubmission(submissionType: SubmissionType.Producer, submissionPeriod: "Apr2026");
+        var submission3 = CreateTestSubmission(submissionType: SubmissionType.Registration, submissionPeriod: "Apr2025");
+        var submissions = new List<AbstractSubmissionGetResponse> { submission1, submission2, submission3 };
+        var requestHandlerDelegate = new Mock<RequestHandlerDelegate<ErrorOr<List<AbstractSubmissionGetResponse>>>>();
+        requestHandlerDelegate.Setup(x => x()).ReturnsAsync(submissions);
+
+        var behaviour = new HydrateSubmissionsBehaviour(_submissionHydrationServiceMock.Object);
+
+        // Act
+        var result = await behaviour.Handle(request, requestHandlerDelegate.Object, cancellationToken);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().HaveCount(3);
+        _submissionHydrationServiceMock.Verify(x => x.Hydrate(submission1), Times.Once);
+        _submissionHydrationServiceMock.Verify(x => x.Hydrate(submission2), Times.Once);
+        _submissionHydrationServiceMock.Verify(x => x.Hydrate(submission3), Times.Once);
+    }
+
+    private TestSubmissionGetResponse CreateTestSubmission(
+        SubmissionType submissionType,
+        string submissionPeriod,
+        Guid? complianceSchemeId = null,
+        string? registrationJourney = null)
+    {
+        return new TestSubmissionGetResponse
+        {
+            Id = Guid.NewGuid(),
+            DataSourceType = DataSourceType.File,
+            SubmissionType = submissionType,
+            SubmissionPeriod = submissionPeriod,
+            OrganisationId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Created = DateTime.UtcNow,
+            ValidationPass = true,
+            HasWarnings = false,
+            Errors = new List<string>(),
+            IsSubmitted = true,
+            ComplianceSchemeId = complianceSchemeId,
+            RegistrationJourney = registrationJourney,
+            RegistrationYear = null
+        };
+    }
+
+    private class TestSubmissionGetResponse : AbstractSubmissionGetResponse
+    {
+        public override bool HasValidFile => true;
+    }
+}

--- a/src/EPR.SubmissionMicroservice.Application/ConfigureServices.cs
+++ b/src/EPR.SubmissionMicroservice.Application/ConfigureServices.cs
@@ -4,9 +4,12 @@ using System.Runtime.CompilerServices;
 using EPR.SubmissionMicroservice.Application.Behaviours;
 using EPR.SubmissionMicroservice.Application.Features.Commands.SubmissionSubmit;
 using EPR.SubmissionMicroservice.Application.Features.Queries.Common;
+using EPR.SubmissionMicroservice.Application.Features.Queries.Common.Interfaces;
+using EPR.SubmissionMicroservice.Application.Features.Queries.Common.Services;
 using EPR.SubmissionMicroservice.Application.Features.Queries.Helpers;
 using EPR.SubmissionMicroservice.Application.Features.Queries.Helpers.Interfaces;
 using EPR.SubmissionMicroservice.Application.Features.Queries.SubmissionGet;
+using EPR.SubmissionMicroservice.Application.Features.Queries.SubmissionsGet;
 using EPR.SubmissionMicroservice.Application.Options;
 using ErrorOr;
 using FluentValidation;
@@ -42,6 +45,7 @@ public static class ConfigureServices
             .AddScoped<ICompaniesHouseSubmissionEventHelper, CompaniesHouseSubmissionEventHelper>()
             .AddScoped<IAccreditationSubmissionEventHelper, AccreditationSubmissionEventHelper>()
             .AddScoped<ISubmissionEventsValidator, SubmissionEventsValidator>()
+            .AddScoped<ISubmissionHydrationService, SubmissionHydrationService>()
             .AddValidatorsFromAssembly(Assembly.GetExecutingAssembly())
             .AddMediatrAndPipelines();
 
@@ -58,6 +62,9 @@ public static class ConfigureServices
                 
                 // GetSubmission chain. QueryHandler -> above behaviours -> Hydrate submission
                 cfg.AddBehavior<IPipelineBehavior<SubmissionGetQuery, ErrorOr<AbstractSubmissionGetResponse>>, HydrateSubmissionBehaviour>();
+                
+                // GetSubmissions chain. QueryHandler -> above behaviours -> Hydrate each submission
+                cfg.AddBehavior<IPipelineBehavior<SubmissionsGetQuery, ErrorOr<List<AbstractSubmissionGetResponse>>>, HydrateSubmissionsBehaviour>();
             });
     }
 }

--- a/src/EPR.SubmissionMicroservice.Application/ConfigureServices.cs
+++ b/src/EPR.SubmissionMicroservice.Application/ConfigureServices.cs
@@ -1,15 +1,20 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using EPR.SubmissionMicroservice.Application.Behaviours;
 using EPR.SubmissionMicroservice.Application.Features.Commands.SubmissionSubmit;
+using EPR.SubmissionMicroservice.Application.Features.Queries.Common;
 using EPR.SubmissionMicroservice.Application.Features.Queries.Helpers;
 using EPR.SubmissionMicroservice.Application.Features.Queries.Helpers.Interfaces;
+using EPR.SubmissionMicroservice.Application.Features.Queries.SubmissionGet;
 using EPR.SubmissionMicroservice.Application.Options;
+using ErrorOr;
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
+[assembly: InternalsVisibleTo("EPR.SubmissionMicroservice.Application.UnitTests")]
 namespace EPR.SubmissionMicroservice.Application;
 
 [ExcludeFromCodeCoverage]
@@ -40,11 +45,19 @@ public static class ConfigureServices
             .AddValidatorsFromAssembly(Assembly.GetExecutingAssembly())
             .AddMediatrAndPipelines();
 
-    private static IServiceCollection AddMediatrAndPipelines(this IServiceCollection services) =>
-        services
-            .AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()))
-            .AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehaviour<,>))
-            .AddTransient(typeof(IPipelineBehavior<,>), typeof(UnhandledExceptionBehaviour<,>))
-            .AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehaviour<,>))
-            .AddTransient(typeof(IPipelineBehavior<,>), typeof(PerformanceBehaviour<,>));
+    private static IServiceCollection AddMediatrAndPipelines(this IServiceCollection services)
+    {
+        return services
+            .AddMediatR(cfg =>
+            {
+                cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly());
+                cfg.AddOpenBehavior(typeof(ValidationBehaviour<,>));
+                cfg.AddOpenBehavior(typeof(UnhandledExceptionBehaviour<,>));
+                cfg.AddOpenBehavior(typeof(LoggingBehaviour<,>));
+                cfg.AddOpenBehavior(typeof(PerformanceBehaviour<,>));
+                
+                // GetSubmission chain. QueryHandler -> above behaviours -> Hydrate submission
+                cfg.AddBehavior<IPipelineBehavior<SubmissionGetQuery, ErrorOr<AbstractSubmissionGetResponse>>, HydrateSubmissionBehaviour>();
+            });
+    }
 }

--- a/src/EPR.SubmissionMicroservice.Application/Features/Queries/Common/AbstractSubmissionGetResponse.cs
+++ b/src/EPR.SubmissionMicroservice.Application/Features/Queries/Common/AbstractSubmissionGetResponse.cs
@@ -33,4 +33,6 @@ public abstract class AbstractSubmissionGetResponse
     public Guid? ComplianceSchemeId { get; set; }
 
     public string? RegistrationJourney { get; set; }
+    
+    public int? RegistrationYear { get; set; }
 }

--- a/src/EPR.SubmissionMicroservice.Application/Features/Queries/Common/Interfaces/ISubmissionHydrationService.cs
+++ b/src/EPR.SubmissionMicroservice.Application/Features/Queries/Common/Interfaces/ISubmissionHydrationService.cs
@@ -1,0 +1,13 @@
+namespace EPR.SubmissionMicroservice.Application.Features.Queries.Common.Interfaces;
+
+/// <summary>
+/// Service for hydrating submission responses with missing data
+/// </summary>
+public interface ISubmissionHydrationService
+{
+    /// <summary>
+    /// Hydrates an AbstractSubmissionGetResponse with missing data such as RegistrationYear and RegistrationJourney
+    /// </summary>
+    /// <param name="submission">The submission response to hydrate</param>
+    void Hydrate(AbstractSubmissionGetResponse submission);
+}

--- a/src/EPR.SubmissionMicroservice.Application/Features/Queries/Common/Services/SubmissionHydrationService.cs
+++ b/src/EPR.SubmissionMicroservice.Application/Features/Queries/Common/Services/SubmissionHydrationService.cs
@@ -1,0 +1,37 @@
+namespace EPR.SubmissionMicroservice.Application.Features.Queries.Common.Services;
+
+using Data.Enums;
+using Interfaces;
+
+/// <summary>
+/// Service for hydrating submission responses with missing data
+/// </summary>
+internal class SubmissionHydrationService : ISubmissionHydrationService
+{
+    /// <summary>
+    /// Hydrates an AbstractSubmissionGetResponse with missing data such as RegistrationYear and RegistrationJourney
+    /// </summary>
+    /// <param name="submission">The submission response to hydrate</param>
+    public void Hydrate(AbstractSubmissionGetResponse submission)
+    {
+        // fill RegistrationYear and RegistrationJourney properties
+        if (submission.SubmissionType == SubmissionType.Registration && submission.SubmissionPeriod.Length >= 4)
+        {
+            // fill registration year
+            // take last 4 characters of submission period
+            var registrationYear = submission.SubmissionPeriod[^4..];
+            var validYear = int.TryParse(registrationYear, out var parsedYear);
+
+            if (validYear)
+            {
+                submission.RegistrationYear = parsedYear;
+
+                // fill reg journey for 2026 large producer CSO journeys (that field may be missing because registration closed before RegistrationJourney was introduced)
+                if (submission.ComplianceSchemeId is not null && parsedYear == 2026 && submission.RegistrationJourney is null)
+                {
+                    submission.RegistrationJourney = RegistrationJourney.CsoLargeProducer.ToString();
+                }
+            }
+        }
+    }
+}

--- a/src/EPR.SubmissionMicroservice.Application/Features/Queries/SubmissionGet/HydrateSubmissionBehaviour.cs
+++ b/src/EPR.SubmissionMicroservice.Application/Features/Queries/SubmissionGet/HydrateSubmissionBehaviour.cs
@@ -1,0 +1,46 @@
+using EPR.SubmissionMicroservice.Application.Features.Queries.Common;
+using EPR.SubmissionMicroservice.Data.Enums;
+using ErrorOr;
+using MediatR;
+
+namespace EPR.SubmissionMicroservice.Application.Features.Queries.SubmissionGet;
+
+/// <summary>
+/// Fills in extra data on the submission that is missing from the database (perhaps due to data issues)
+/// </summary>
+internal class HydrateSubmissionBehaviour : IPipelineBehavior<SubmissionGetQuery, ErrorOr<AbstractSubmissionGetResponse>>
+{
+    public async Task<ErrorOr<AbstractSubmissionGetResponse>> Handle(SubmissionGetQuery request, RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>> next, CancellationToken cancellationToken)
+    {
+        var response = await next();
+
+        if (response.IsError)
+        {
+            return response;
+        }
+        
+        var submission = response.Value;
+        
+        // fill RegistrationYear and RegistrationJourney properties
+        if (submission.SubmissionType == SubmissionType.Registration && submission.SubmissionPeriod.Length >= 4)
+        {
+            // fill registration year
+            // take last 4 characters of submission period
+            var registrationYear = submission.SubmissionPeriod[^4..];
+            var validYear = int.TryParse(registrationYear, out var parsedYear);
+
+            if (validYear)
+            {
+                submission.RegistrationYear = parsedYear;
+
+                // fill reg journey for 2026 large producer CSO journeys (that field may be missing because registration closed before RegistrationJourney was introduced)
+                if (submission.ComplianceSchemeId is not null && parsedYear == 2026 && submission.RegistrationJourney is null)
+                {
+                    submission.RegistrationJourney = RegistrationJourney.CsoLargeProducer.ToString();
+                }
+            }
+        }
+        
+        return submission;
+    }
+}

--- a/src/EPR.SubmissionMicroservice.Application/Features/Queries/SubmissionGet/HydrateSubmissionBehaviour.cs
+++ b/src/EPR.SubmissionMicroservice.Application/Features/Queries/SubmissionGet/HydrateSubmissionBehaviour.cs
@@ -1,5 +1,5 @@
 using EPR.SubmissionMicroservice.Application.Features.Queries.Common;
-using EPR.SubmissionMicroservice.Data.Enums;
+using EPR.SubmissionMicroservice.Application.Features.Queries.Common.Interfaces;
 using ErrorOr;
 using MediatR;
 
@@ -10,6 +10,13 @@ namespace EPR.SubmissionMicroservice.Application.Features.Queries.SubmissionGet;
 /// </summary>
 internal class HydrateSubmissionBehaviour : IPipelineBehavior<SubmissionGetQuery, ErrorOr<AbstractSubmissionGetResponse>>
 {
+    private readonly ISubmissionHydrationService _submissionHydrationService;
+
+    public HydrateSubmissionBehaviour(ISubmissionHydrationService submissionHydrationService)
+    {
+        _submissionHydrationService = submissionHydrationService;
+    }
+
     public async Task<ErrorOr<AbstractSubmissionGetResponse>> Handle(SubmissionGetQuery request, RequestHandlerDelegate<ErrorOr<AbstractSubmissionGetResponse>> next, CancellationToken cancellationToken)
     {
         var response = await next();
@@ -19,28 +26,8 @@ internal class HydrateSubmissionBehaviour : IPipelineBehavior<SubmissionGetQuery
             return response;
         }
         
-        var submission = response.Value;
+        _submissionHydrationService.Hydrate(response.Value);
         
-        // fill RegistrationYear and RegistrationJourney properties
-        if (submission.SubmissionType == SubmissionType.Registration && submission.SubmissionPeriod.Length >= 4)
-        {
-            // fill registration year
-            // take last 4 characters of submission period
-            var registrationYear = submission.SubmissionPeriod[^4..];
-            var validYear = int.TryParse(registrationYear, out var parsedYear);
-
-            if (validYear)
-            {
-                submission.RegistrationYear = parsedYear;
-
-                // fill reg journey for 2026 large producer CSO journeys (that field may be missing because registration closed before RegistrationJourney was introduced)
-                if (submission.ComplianceSchemeId is not null && parsedYear == 2026 && submission.RegistrationJourney is null)
-                {
-                    submission.RegistrationJourney = RegistrationJourney.CsoLargeProducer.ToString();
-                }
-            }
-        }
-        
-        return submission;
+        return response;
     }
 }

--- a/src/EPR.SubmissionMicroservice.Application/Features/Queries/SubmissionsGet/HydrateSubmissionsBehaviour.cs
+++ b/src/EPR.SubmissionMicroservice.Application/Features/Queries/SubmissionsGet/HydrateSubmissionsBehaviour.cs
@@ -1,0 +1,39 @@
+namespace EPR.SubmissionMicroservice.Application.Features.Queries.SubmissionsGet;
+
+using Common;
+using Common.Interfaces;
+using ErrorOr;
+using MediatR;
+
+/// <summary>
+/// Fills in extra data on each submission in the list that is missing from the database (perhaps due to data issues)
+/// </summary>
+internal class HydrateSubmissionsBehaviour : IPipelineBehavior<SubmissionsGetQuery, ErrorOr<List<AbstractSubmissionGetResponse>>>
+{
+    private readonly ISubmissionHydrationService _submissionHydrationService;
+
+    public HydrateSubmissionsBehaviour(ISubmissionHydrationService submissionHydrationService)
+    {
+        _submissionHydrationService = submissionHydrationService;
+    }
+
+    public async Task<ErrorOr<List<AbstractSubmissionGetResponse>>> Handle(
+        SubmissionsGetQuery request,
+        RequestHandlerDelegate<ErrorOr<List<AbstractSubmissionGetResponse>>> next,
+        CancellationToken cancellationToken)
+    {
+        var response = await next();
+
+        if (response.IsError)
+        {
+            return response;
+        }
+
+        foreach (var submission in response.Value)
+        {
+            _submissionHydrationService.Hydrate(submission);
+        }
+
+        return response;
+    }
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SUB-149

Submission data in the cosmos collection is sometimes missing registration journey values (we have work arounds for querying those records already). This PR ensures that the logical registration journey is returned when retrieving submissions (ie, for 2026 large producers who registered before the registration journey was introduced). Also added the `registrationYear` to the response, which is derived from the `submissionPeriod` for registrations.

* Added `HydrateSubmissionBehaviour`, `HydrateSubmissionsBehaviour` into the Get submission(s) pipeline, and `SubmissionHydrationService` to contain shared logic
* Added unit tests

<img width="1005" height="1029" alt="image" src="https://github.com/user-attachments/assets/2454f599-b0e1-406a-a5e3-776fee3f2de5" />
