### PR TITLE
SUB-238: service bus emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -411,3 +411,6 @@ FodyWeavers.xsd
 
 # Local Cosmos emulator TLS export (docker compose cert-export service)
 tests/integration/.cosmos-certs/
+
+# Docker
+.env

--- a/README.md
+++ b/README.md
@@ -29,7 +29,18 @@ Clone the [epr_common](https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_git/e
 
 ### Run
 
-- Complete `appsettings.json` file (or `appsettings.Development.json` if exists) with correct details
+1. Navigate to the project directory:
+1. Complete `appsettings.json` file (or `appsettings.Development.json` if exists) with correct details
+1. Start docker
+1. If you don't have one already, create a `.env` file in the root of the project. It should contain the sql password, in the form `SQL_PASSWORD=foobar`
+1. If you haven't pulled the docker images before, run
+   `docker compose pull`
+1. Run the docker containers
+   `docker compose up`
+1. To run the service locally:
+    ```bash
+    dotnet run
+    ```
 - On `EPR.SubmissionMicroservice.API` directory, execute:
 ```
 dotnet run

--- a/compose.yml
+++ b/compose.yml
@@ -7,3 +7,43 @@ services:
       - "1234:1234"
     environment:
       PROTOCOL: https
+
+  servicebus-emulator:
+    container_name: "submissions-api-servicebus-emulator"
+    image: mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
+    pull_policy: always
+    volumes:
+      - "./docker-compose-servicebus-config.json:/ServiceBus_Emulator/ConfigFiles/Config.json"
+    ports:
+      - "5672:5672"
+      - "5300:5300"
+    environment:
+      SQL_SERVER: sql
+      MSSQL_SA_PASSWORD: "${SQL_PASSWORD}"  # Password should be same as what is set for SQL Edge  
+      ACCEPT_EULA: "Y"
+    depends_on:
+      sql:
+        condition: service_started
+    networks:
+      sb-emulator:
+        aliases:
+          - "sb-emulator"
+
+  sql:
+    container_name: submissions-api-sql
+    image: mcr.microsoft.com/azure-sql-edge
+    restart: always
+    cap_add:
+      - SYS_PTRACE
+    ports:
+      - "1433:1433"
+    networks:
+      sb-emulator:
+        aliases:
+          - "sql"
+    environment:
+      - ACCEPT_EULA=1
+      - SA_PASSWORD=${SQL_PASSWORD}
+
+networks:
+  sb-emulator:

--- a/docker-compose-servicebus-config.json
+++ b/docker-compose-servicebus-config.json
@@ -1,0 +1,52 @@
+{
+    "UserConfig": {
+        "Namespaces": [
+            {
+                "Name": "sbemulatorns",
+                "Queues": [
+                    {
+                        "Name": "queue.1",
+                        "Properties": {
+                            "DeadLetteringOnMessageExpiration": false,
+                            "DefaultMessageTimeToLive": "PT1H",
+                            "DuplicateDetectionHistoryTimeWindow": "PT20S",
+                            "ForwardDeadLetteredMessagesTo": "",
+                            "ForwardTo": "",
+                            "LockDuration": "PT1M",
+                            "MaxDeliveryCount": 3,
+                            "RequiresDuplicateDetection": false,
+                            "RequiresSession": false
+                        }
+                    }
+                ],
+                "Topics": [
+                    {
+                        "Name": "topic.1",
+                        "Properties": {
+                            "DefaultMessageTimeToLive": "PT1H",
+                            "DuplicateDetectionHistoryTimeWindow": "PT20S",
+                            "RequiresDuplicateDetection": false
+                        },
+                        "Subscriptions": [
+                            {
+                                "Name": "subscription.1",
+                                "Properties": {
+                                    "DeadLetteringOnMessageExpiration": false,
+                                    "DefaultMessageTimeToLive": "PT1H",
+                                    "LockDuration": "PT1M",
+                                    "MaxDeliveryCount": 3,
+                                    "ForwardDeadLetteredMessagesTo": "",
+                                    "ForwardTo": "",
+                                    "RequiresSession": false
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "Logging": {
+            "Type": "File"
+        }
+    }
+}

--- a/src/EPR.SubmissionMicroservice.API/appsettings.json
+++ b/src/EPR.SubmissionMicroservice.API/appsettings.json
@@ -26,5 +26,8 @@
     },
     "Validation": {
         "MaxIssuesToProcess": 1000
-    }
-}
+    },
+    "ServiceBus": {
+        "ConnectionString": "",
+        "AdminConnectionString": ""
+    }}

--- a/src/EPR.SubmissionMicroservice.sln
+++ b/src/EPR.SubmissionMicroservice.sln
@@ -27,6 +27,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\README.md = ..\README.md
 		..\CONTRIBUTING.md = ..\CONTRIBUTING.md
 		..\LICENCE.md = ..\LICENCE.md
+		..\docker-compose-servicebus-config.json = ..\docker-compose-servicebus-config.json
+		..\compose.yml = ..\compose.yml
+		..\.gitignore = ..\.gitignore
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SUB-238

Added ability to run service bus emulator locally in docker

* Added service bus emulator to `compose.yml`, and associated sql (used by the emulator)
* Updated readme
* Updated `.gitignore`
* Added service bus config to appsettings. Unfortunately, the admin connection string is needed for the emulator

<img width="1535" height="918" alt="image" src="https://github.com/user-attachments/assets/58f3f143-1e89-4c91-85a2-92a77c3aec44" />
