### PR TITLE
Feature/sub 238 integration tests

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -3,5 +3,5 @@ ee022e9c128904dcfaa6a589caa005d1b8f2c715:src/EPR.SubmissionMicroservice.API/apps
 4d13fbdf64fe5e987380cd3015802127a521de6d:src/EPR.SubmissionMicroservice.API/appsettings.json:generic-api-key:10
 675b02cf1bb3109bf8ec90819685e50463fc14f9:src/EPR.SubmissionMicroservice.API/appsettings.json:generic-api-key:10
 245328ae10630a74222ef74e62e5e1773ad1de85:src/EPR.SubmissionMicroservice.API.IntegrationTests/appsettings.test.json:generic-api-key:7
-245328ae10630a74222ef74e62e5e1773ad1de85:src/EPR.SubmissionMicroservice.API.IntegrationTests/appsettings.test.json:generic-api-key:10
-245328ae10630a74222ef74e62e5e1773ad1de85:src/EPR.SubmissionMicroservice.API.IntegrationTests/appsettings.test.json:generic-api-key:11
+245328ae10630a74222ef74e62e5e1773ad1de85:src/EPR.SubmissionMicroservice.API.IntegrationTests/appsettings.test.json:azure-messaging-connection-string-shared-access-key:10
+245328ae10630a74222ef74e62e5e1773ad1de85:src/EPR.SubmissionMicroservice.API.IntegrationTests/appsettings.test.json:azure-messaging-connection-string-shared-access-key:11

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -2,3 +2,6 @@ a16a04749314e89ae1c22158ef6b02e2122adb43:src/EPR.SubmissionMicroservice.API/apps
 ee022e9c128904dcfaa6a589caa005d1b8f2c715:src/EPR.SubmissionMicroservice.API/appsettings.json:generic-api-key:16
 4d13fbdf64fe5e987380cd3015802127a521de6d:src/EPR.SubmissionMicroservice.API/appsettings.json:generic-api-key:10
 675b02cf1bb3109bf8ec90819685e50463fc14f9:src/EPR.SubmissionMicroservice.API/appsettings.json:generic-api-key:10
+245328ae10630a74222ef74e62e5e1773ad1de85:src/EPR.SubmissionMicroservice.API.IntegrationTests/appsettings.test.json:generic-api-key:7
+245328ae10630a74222ef74e62e5e1773ad1de85:src/EPR.SubmissionMicroservice.API.IntegrationTests/appsettings.test.json:generic-api-key:10
+245328ae10630a74222ef74e62e5e1773ad1de85:src/EPR.SubmissionMicroservice.API.IntegrationTests/appsettings.test.json:generic-api-key:11

--- a/README.md
+++ b/README.md
@@ -75,20 +75,13 @@ N/A
 ### Integration tests
 Integration tests use Azure Cosmos DB and can be run locally with the Cosmos Emulator in Docker.
 
-**Cosmos account key (required):** The test harness does not embed an account key. You must provide the Cosmos DB primary key before running integration tests:
-
-- **CI / pipelines:** Inject the `CosmosAccountKey` environment variable (for example as a secret variable mapped in your pipeline). The integration test project reads `CosmosAccountKey` and sets `Database__AccountKey` for the test host.
-- **Local:** Export `CosmosAccountKey` to your emulator’s primary key (see [Azure Cosmos DB Emulator](https://learn.microsoft.com/azure/cosmos-db/emulator)) or set `Database__AccountKey` directly instead. You must also set the `SQL_PASSWORD` environment variable as per the [Run](#run) instructions
 
 Example local run (after starting the emulator):
 
 ```bash
-export CosmosAccountKey="<your-cosmos-primary-key>"
 docker compose up
 dotnet test ./src/EPR.SubmissionMicroservice.API.IntegrationTests/EPR.SubmissionMicroservice.API.IntegrationTests.csproj --filter "Category=IntegrationTest"
 ```
-
-If running in **Rider**, you can set environment variables for the test runner in the Settings | Build, Execution, Deployment | Unit Testing | Test Runner settings
 
 Route-to-test mapping for maintenance: [tests/integration/INTEGRATION_COVERAGE_CHECKLIST.md](tests/integration/INTEGRATION_COVERAGE_CHECKLIST.md).
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Integration tests use Azure Cosmos DB and can be run locally with the Cosmos Emu
 **Cosmos account key (required):** The test harness does not embed an account key. You must provide the Cosmos DB primary key before running integration tests:
 
 - **CI / pipelines:** Inject the `CosmosAccountKey` environment variable (for example as a secret variable mapped in your pipeline). The integration test project reads `CosmosAccountKey` and sets `Database__AccountKey` for the test host.
-- **Local:** Export `CosmosAccountKey` to your emulator’s primary key (see [Azure Cosmos DB Emulator](https://learn.microsoft.com/azure/cosmos-db/emulator)) or set `Database__AccountKey` directly instead.
+- **Local:** Export `CosmosAccountKey` to your emulator’s primary key (see [Azure Cosmos DB Emulator](https://learn.microsoft.com/azure/cosmos-db/emulator)) or set `Database__AccountKey` directly instead. You must also set the `SQL_PASSWORD` environment variable as per the [Run](#run) instructions
 
 Example local run (after starting the emulator):
 
@@ -87,6 +87,8 @@ export CosmosAccountKey="<your-cosmos-primary-key>"
 docker compose up
 dotnet test ./src/EPR.SubmissionMicroservice.API.IntegrationTests/EPR.SubmissionMicroservice.API.IntegrationTests.csproj --filter "Category=IntegrationTest"
 ```
+
+If running in **Rider**, you can set environment variables for the test runner in the Settings | Build, Execution, Deployment | Unit Testing | Test Runner settings
 
 Route-to-test mapping for maintenance: [tests/integration/INTEGRATION_COVERAGE_CHECKLIST.md](tests/integration/INTEGRATION_COVERAGE_CHECKLIST.md).
 

--- a/pipelines/ci_pipeline.yaml
+++ b/pipelines/ci_pipeline.yaml
@@ -43,8 +43,9 @@ variables:
 resources:
   repositories:
     - repository: CommonTemplates
-      name: RWD-CPR-EPR4P-ADO/epr-webapps-code-deploy-templates
-      type: git
+      name: defra/epr-webapps-code-deploy-templates
+      type: github
+      endpoint: defra
       ref: main
 
 extends:

--- a/pipelines/deployment-pipeline.yaml
+++ b/pipelines/deployment-pipeline.yaml
@@ -72,8 +72,9 @@ variables:
 resources:
   repositories:
     - repository: CommonTemplates
-      name: RWD-CPR-EPR4P-ADO/epr-webapps-code-deploy-templates
-      type: git
+      name: defra/epr-webapps-code-deploy-templates
+      type: github
+      endpoint: defra
       ref: main
 
     # The repo will be reference the repo by a release tag (if the imageTag parameter contains 'release') otherwise it will pull down the main branch.

--- a/src/EPR.SubmissionMicroservice.API.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/src/EPR.SubmissionMicroservice.API.IntegrationTests/CustomWebApplicationFactory.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace EPR.SubmissionMicroservice.API.IntegrationTests;
+
+internal class CustomWebApplicationFactory(IConfiguration? configuration = null) : WebApplicationFactory<Program>
+{
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        builder.ConfigureHostConfiguration(config =>
+        {
+            // config here is in the context of the host - the web application - so this
+            // builds it from the web application's appsettings file
+            config.AddJsonFile("appsettings.json");
+            
+            // And then add any custom config passed in from the test project
+            if (configuration != null)
+            {
+                config.AddConfiguration(configuration);
+            }
+        });
+        return base.CreateHost(builder);
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseSetting("https_port", "80");
+    }
+}

--- a/src/EPR.SubmissionMicroservice.API.IntegrationTests/EPR.SubmissionMicroservice.API.IntegrationTests.csproj
+++ b/src/EPR.SubmissionMicroservice.API.IntegrationTests/EPR.SubmissionMicroservice.API.IntegrationTests.csproj
@@ -22,4 +22,9 @@
       <ProjectReference Include="..\TestSupport\TestSupport.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <None Update="appsettings.test.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 </Project>

--- a/src/EPR.SubmissionMicroservice.API.IntegrationTests/TestBase.cs
+++ b/src/EPR.SubmissionMicroservice.API.IntegrationTests/TestBase.cs
@@ -16,16 +16,6 @@ using Data.Enums;
 
 public class TestBase
 {
-    /// <summary>
-    /// CI/local env var name for the Cosmos DB primary key (built via <see cref="string.Concat(string, string, string)"/> so secret scanners do not see a single literal matching common Azure key patterns).
-    /// </summary>
-    private static string CosmosPrimaryKeyEnvVarName => string.Concat("Cosmos", "Account", "Key");
-
-    /// <summary>
-    /// Config key forwarded to the test host for the DB primary key (same concatenation approach as <see cref="CosmosPrimaryKeyEnvVarName"/>).
-    /// </summary>
-    private static string DatabasePrimaryKeySettingName => string.Concat("Database__", "Account", "Key");
-
     private const string EmulatorDatabaseName = "SubmissionDB";
     private const string LoggingApiBaseUrl = "http://localhost";
     protected readonly string OrganisationId = Guid.NewGuid().ToString();
@@ -53,20 +43,6 @@ public class TestBase
 
     private static void ConfigureEmulatorDefaults()
     {
-        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(DatabasePrimaryKeySettingName)))
-        {
-            var primaryKeyFromEnvironment = Environment.GetEnvironmentVariable(CosmosPrimaryKeyEnvVarName);
-            if (string.IsNullOrWhiteSpace(primaryKeyFromEnvironment))
-            {
-                throw new InvalidOperationException(
-                    $"Integration tests require a Cosmos DB account key. Set the '{CosmosPrimaryKeyEnvVarName}' " +
-                    $"environment variable (injected by CI), or set '{DatabasePrimaryKeySettingName}' directly. " +
-                    "For the Azure Cosmos DB Emulator, use the primary key from the emulator / Microsoft documentation.");
-            }
-
-            Environment.SetEnvironmentVariable(DatabasePrimaryKeySettingName, primaryKeyFromEnvironment);
-        }
-
         if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("LoggingApi__BaseUrl")))
         {
             Environment.SetEnvironmentVariable("LoggingApi__BaseUrl", LoggingApiBaseUrl);

--- a/src/EPR.SubmissionMicroservice.API.IntegrationTests/TestBase.cs
+++ b/src/EPR.SubmissionMicroservice.API.IntegrationTests/TestBase.cs
@@ -1,4 +1,6 @@
-﻿namespace EPR.SubmissionMicroservice.API.IntegrationTests;
+﻿using Microsoft.Extensions.Configuration;
+
+namespace EPR.SubmissionMicroservice.API.IntegrationTests;
 
 using System.Net;
 using System.Net.Http.Headers;
@@ -24,7 +26,6 @@ public class TestBase
     /// </summary>
     private static string DatabasePrimaryKeySettingName => string.Concat("Database__", "Account", "Key");
 
-    private const string EmulatorEndpoint = "https://localhost:8081/";
     private const string EmulatorDatabaseName = "SubmissionDB";
     private const string LoggingApiBaseUrl = "http://localhost";
     protected readonly string OrganisationId = Guid.NewGuid().ToString();
@@ -35,28 +36,23 @@ public class TestBase
     {
         ConfigureEmulatorDefaults();
 
-        var application = new WebApplicationFactory<Program>()
-            .WithWebHostBuilder(builder =>
-            {
-                builder.UseSetting("https_port", "80");
-            });
+        // builds config from only the test appsettings
+        var testConfig = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.test.json")
+            .Build();
 
-        HttpClient = application.CreateDefaultClient();
+        var factory = new CustomWebApplicationFactory(testConfig);
+        HttpClient = factory.CreateClient();
         HttpClient.BaseAddress = new Uri("https://localhost:8000");
         HttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         HttpClient.DefaultRequestHeaders.Add("organisationId", OrganisationId);
         HttpClient.DefaultRequestHeaders.Add("userId", _userId);
 
-        EnsureCosmosContainersCreated(application.Services);
+        EnsureCosmosContainersCreated(factory.Services);
     }
 
     private static void ConfigureEmulatorDefaults()
     {
-        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("Database__ConnectionString")))
-        {
-            Environment.SetEnvironmentVariable("Database__ConnectionString", EmulatorEndpoint);
-        }
-
         if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(DatabasePrimaryKeySettingName)))
         {
             var primaryKeyFromEnvironment = Environment.GetEnvironmentVariable(CosmosPrimaryKeyEnvVarName);
@@ -69,11 +65,6 @@ public class TestBase
             }
 
             Environment.SetEnvironmentVariable(DatabasePrimaryKeySettingName, primaryKeyFromEnvironment);
-        }
-
-        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("Database__Name")))
-        {
-            Environment.SetEnvironmentVariable("Database__Name", EmulatorDatabaseName);
         }
 
         if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("LoggingApi__BaseUrl")))

--- a/src/EPR.SubmissionMicroservice.API.IntegrationTests/appsettings.test.json
+++ b/src/EPR.SubmissionMicroservice.API.IntegrationTests/appsettings.test.json
@@ -1,0 +1,13 @@
+{
+  "LoggingApi": {
+    "BaseUrl": "https://devrwdwebwa9403.azurewebsites.net"
+  },
+  "Database": {
+    "ConnectionString": "https://localhost:8081/",
+    "AccountKey": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+  },
+  "ServiceBus": {
+    "ConnectionString": "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
+    "AdminConnectionString": "Endpoint=http://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true"
+  }
+}

--- a/src/EPR.SubmissionMicroservice.Application/Messaging/Publishing/RegistrationSubmittedForFeesCalculationEvent.cs
+++ b/src/EPR.SubmissionMicroservice.Application/Messaging/Publishing/RegistrationSubmittedForFeesCalculationEvent.cs
@@ -1,3 +1,0 @@
-namespace EPR.SubmissionMicroservice.Application.Messaging.Publishing;
-
-public record RegistrationSubmittedForFeesCalculationEvent(string SubmissionId, DateTime CreatedDate);

--- a/src/EPR.SubmissionMicroservice.Application/Messaging/Publishing/RegistrationSubmittedForFeesCalculationEvent.cs
+++ b/src/EPR.SubmissionMicroservice.Application/Messaging/Publishing/RegistrationSubmittedForFeesCalculationEvent.cs
@@ -1,0 +1,3 @@
+namespace EPR.SubmissionMicroservice.Application.Messaging.Publishing;
+
+public record RegistrationSubmittedForFeesCalculationEvent(string SubmissionId, DateTime CreatedDate);


### PR DESCRIPTION
Use `appsettings.test.json` for integration tests. This makes the tests easier to run, with fewer pipeline dependencies.

Updated the build pipelines.